### PR TITLE
rewrite for WebSub, no FHIR Subscriptions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,16 +36,16 @@ Subscriber performs an HTTP POST to the hub base url with the following paramete
 
 Field | Optionality | Type | Description
 ---------- | ----- | -------- | --------------
-hub.callback | Required | string | The Subscriber's callback URL where notifications should be delivered. The callback URL SHOULD be an unguessable URL that is unique per subscription.
-hub.mode | Required | string | The literal string "subscribe" or "unsubscribe", depending on the goal of the request.
-hub.topic | Required | string | The identifier of the user's session that the subscriber wishes to subscribe to or unsubscribe from. 
-hub.secret | Required | string | A subscriber-provided cryptographically random unique secret string that will be used to compute an HMAC digest delivered in each notification. This parameter MUST be less than 200 bytes in length.
-hub.events | Required | string | Comma-separated list of event types from the Event Catalog for which the Subscriber wants notifications.
-hub.lease_seconds | Optional | number | Number of seconds for which the subscriber would like to have the subscription active, given as a positive decimal integer. Hubs MAY choose to respect this value or not, depending on their own policies, and MAY set a default value if the subscriber omits the parameter. 
+`hub.callback` | Required | *string* | The Subscriber's callback URL where notifications should be delivered. The callback URL SHOULD be an unguessable URL that is unique per subscription.
+`hub.mode` | Required | *string* | The literal string "subscribe" or "unsubscribe", depending on the goal of the request.
+`hub.topic` | Required | *string* | The identifier of the user's session that the subscriber wishes to subscribe to or unsubscribe from. 
+`hub.secret` | Required | *string* | A subscriber-provided cryptographically random unique secret string that will be used to compute an HMAC digest delivered in each notification. This parameter MUST be less than 200 bytes in length.
+`hub.events` | Required | *string* | Comma-separated list of event types from the Event Catalog for which the Subscriber wants notifications.
+`hub.lease_seconds` | Optional | *number* | Number of seconds for which the subscriber would like to have the subscription active, given as a positive decimal integer. Hubs MAY choose to respect this value or not, depending on their own policies, and MAY set a default value if the subscriber omits the parameter. 
 
-Hubs MUST allow subscribers to re-request subscriptions that are already activated. Each subsequent request to a hub to subscribe or unsubscribe MUST override the previous subscription state for a specific topic, and callback URL combination once the action is verified. 
+Hubs MUST allow subscribers to re-request subscriptions that are already activated. Each subsequent request to a hub to subscribe or unsubscribe MUST override the previous subscription state for a specific topic, and callback URL combination once the action is verified. 
 
-The callback URL MAY contain arbitrary query string parameters (e.g., ?foo=bar&red=fish). Hubs MUST preserve the query string during subscription verification by appending new parameters to the end of the list using the & (ampersand) character to join. When sending the content distribution request, the hub will make a POST request to the callback URL including any query string parameters in the URL portion of the request, not as POST body parameters.
+The callback URL MAY contain arbitrary query string parameters (e.g., ?foo=bar&red=fish). Hubs MUST preserve the query string during subscription verification by appending new parameters to the end of the list using the & (ampersand) character to join. When sending the content distribution request, the hub will make a POST request to the callback URL including any query string parameters in the URL portion of the request, not as POST body parameters.
 
 ```
 POST https://hub.example.com
@@ -57,9 +57,9 @@ hub.callback=https%3A%2F%2Fapp.example.com%2Fsession%2Fcallback%2Fv7tfwuk17a&hub
 ```
 
 #### Hub responds with successful creation
-If the hub URL supports FHIRcast and is able to handle the subscription or unsubscription request, it MUST respond to a subscription request with an HTTP 202 "Accepted" response to indicate that the request was received and will now be verified by the hub. The hub SHOULD perform the verification of intent as soon as possible.
+If the hub URL supports FHIRcast and is able to handle the subscription or unsubscription request, it MUST respond to a subscription request with an HTTP 202 "Accepted" response to indicate that the request was received and will now be verified by the hub. The hub SHOULD perform the verification of intent as soon as possible.
 
-If a hub finds any errors in the subscription request, an appropriate HTTP error response code (4xx or 5xx) MUST be returned. In the event of an error, hubs SHOULD return a description of the error in the response body as plain text, used to assist the client developer in understanding the error. This is not meant to be shown to the end user. Hubs MAY decide to reject some callback URLs or topic URLs based on their own policies.
+If a hub finds any errors in the subscription request, an appropriate HTTP error response code (4xx or 5xx) MUST be returned. In the event of an error, hubs SHOULD return a description of the error in the response body as plain text, used to assist the client developer in understanding the error. This is not meant to be shown to the end user. Hubs MAY decide to reject some callback URLs or topic URLs based on their own policies.
 
 ```
 HTTP/1.1 202 Accepted
@@ -71,10 +71,10 @@ If (and when) the subscription is denied, the hub MUST inform the subscriber by 
 
 Field | Optionality | Type | Description
 --- | --- | --- | ---
-hub.mode | Required | string | The literal string "denied".
-hub.topic | Required | string | The topic given in the corresponding subscription request.
-hub.events| Required | string | A comma-separated list of events from the Event Catalog corresponding to the events string given in the corresponding subscription request. 
-hub.reason | Optional | string | The hub may include a reason for which the subscription has been denied. The subscription MAY be denied by the hub at any point (even if it was previously accepted). The Subscriber SHOULD then consider that the subscription is not possible anymore.
+`hub.mode` | Required | *string* | The literal string "denied".
+`hub.topic` | Required | *string* | The topic given in the corresponding subscription request.
+`hub.events` | Required | *string* | A comma-separated list of events from the Event Catalog corresponding to the events string given in the corresponding subscription request. 
+`hub.reason` | Optional | *string* | The hub may include a reason for which the subscription has been denied. The subscription MAY be denied by the hub at any point (even if it was previously accepted). The Subscriber SHOULD then consider that the subscription is not possible anymore.
 
 ```
 GET https://app.example.com/session/callback/v7tfwuk17a?hub.mode=denied&hub.topic=7jaa86kgdudewiaq0wtu&hub.events=patient-open-chart,patient-close-chart&hub.challenge=meu3we944ix80ox&hub.reason=session+unexpectedly+stopped HTTP 1.1
@@ -89,18 +89,18 @@ In order to prevent an attacker from creating unwanted subscriptions on behalf o
 
 Field | Optionality | Type | Description
 ---  | --- | --- | --- 
-hub.mode | Required | string | The literal string "subscribe" or "unsubscribe", which matches the original request to the hub from the subscriber.
-hub.topic | Required | string | The topic session id given in the corresponding subscription request.
-hub.events| Required | string | A comma-separated list of events from the Event Catalog corresponding to the events string given in the corresponding subscription request. 
-hub.challenge | Required | string | A hub-generated, random string that MUST be echoed by the subscriber to verify the subscription.
-hub.lease_seconds | Required | number | The hub-determined number of seconds that the subscription will stay active before expiring, measured from the time the verification request was made from the hub to the subscriber. Subscribers must renew their subscription before the lease seconds period is over to avoid interruption. 
+`hub.mode` | Required | *string* | The literal string "subscribe" or "unsubscribe", which matches the original request to the hub from the subscriber.
+`hub.topic` | Required | *string* | The topic session id given in the corresponding subscription request.
+`hub.events` | Required | *string* | A comma-separated list of events from the Event Catalog corresponding to the events string given in the corresponding subscription request. 
+`hub.challenge` | Required | *string* | A hub-generated, random string that MUST be echoed by the subscriber to verify the subscription.
+`hub.lease_seconds` | Required | *number* | The hub-determined number of seconds that the subscription will stay active before expiring, measured from the time the verification request was made from the hub to the subscriber. Subscribers must renew their subscription before the lease seconds period is over to avoid interruption. 
 
 ```
 GET https://app.example.com/session/callback/v7tfwuk17a?hub.mode=subscribe&hub.topic=7jaa86kgdudewiaq0wtu&hub.events=patient-open-chart,patient-close-chart&hub.challenge=meu3we944ix80ox HTTP 1.1
 Host: subscriber
 ```
 
-The subscriber MUST confirm that the hub.topic corresponds to a pending subscription or unsubscription that it wishes to carry out. If so, the subscriber MUST respond with an HTTP success (2xx) code with a response body equal to the hub.challenge parameter. If the subscriber does not agree with the action, the subscriber MUST respond with a 404 "Not Found" response.
+The subscriber MUST confirm that the hub.topic corresponds to a pending subscription or unsubscription that it wishes to carry out. If so, the subscriber MUST respond with an HTTP success (2xx) code with a response body equal to the hub.challenge parameter. If the subscriber does not agree with the action, the subscriber MUST respond with a 404 "Not Found" response.
 
 ```
 HTTP/1.1 200 Success
@@ -109,7 +109,7 @@ Content-Type: text/html
 meu3we944ix80ox
 ```
 
-The hub MUST consider other server response codes (3xx, 4xx, 5xx) to mean that the verification request has failed. If the subscriber returns an HTTP success (2xx) but the content body does not match the hub.challenge parameter, the hub MUST also consider verification to have failed.
+The hub MUST consider other server response codes (3xx, 4xx, 5xx) to mean that the verification request has failed. If the subscriber returns an HTTP success (2xx) but the content body does not match the hub.challenge parameter, the hub MUST also consider verification to have failed.
 
 ### Workflow event occurs and subscriber is notified
 
@@ -119,15 +119,21 @@ Using the hub.secret from the subscription request, the hub MUST generate an HMA
 
 Field | Optionality | Type | Description
 --- | --- | --- | ---
-Timestamp | Required | string | ISO 8601 timestamp in UTC describing the time at which the event occurred with subsecond accuracy. 
-Id | Required | string | Event identifier used to recognize retried notifications. This id MUST be globally unique for the hub, SHOULD be opaque to the subscriber and MAY be a GUID.
-Event | Required | object | A json object describing the event. See below.
+`timestamp` | Required | *string* | ISO 8601 timestamp in UTC describing the time at which the event occurred with subsecond accuracy. 
+`id` | Required | *string* | Event identifier used to recognize retried notifications. This id MUST be globally unique for the hub, SHOULD be opaque to the subscriber and MAY be a GUID.
+`event` | Required | *object* | A json object describing the event. See below.
+
 
 Field | Optionality | Type | Description
 --- | --- | --- | ---
 hub.topic | Required | string | The topic session id given in the subscription request. 
 hub.event| Required | string | The event that triggered this notification, taken from the list of events from the subscription request.
-subject | Required | array | A json array containing the new _focus_ of the user's session in the form of urls to FHIR resources. Common FHIR resources are: Patient, Encounter, ImagingStudy and List. The hub MUST only return FHIR resources that can be accessed with the existing OAuth2 access_token.
+context | Required | array | An array of named FHIR objects corresponding to the user's context after the given event has occurred. Common FHIR resources are: Patient, Encounter, ImagingStudy and List. The hub MUST only return FHIR resources that can be accessed with the existing OAuth2 access_token.
+
+#### What just happened in the user's session?
+The notification's hub.event and context fields inform the subscriber of the current state of the user's session. The hub.event is a user workflow event, from the Event Catalog. The context is an array of named FHIR objects (similar to [CDS Hooks's context](https://cds-hooks.org/specification/1.0/#http-request_1) field) that describe the current content of the user's session. Each event in the Event Catalog defines what context is expected in the notification. The context makes heavy use of the [FHIR _elements parameter](https://www.hl7.org/fhir/search.html#elements) to limit the size of the data being passed while also including additional, local identifiers that are likely already in use in production implementations. 
+
+
 ```
 POST https://app.example.com/session/callback/v7tfwuk17a HTTP/1.1
 Host: subscriber
@@ -136,14 +142,29 @@ X-Hub-Signature: sha256=dce85dc8dfde2426079063ad413268ac72dcf845f9f923193285e693
 {
   "timestamp": "2018-01-08T01:37:05.14",
   "id": "q9v3jubddqt63n1",
-  "event":   {
-	  "hub.topic": "7jaa86kgdudewiaq0wtu",
-	  "hub.event": "open-patient-chart",
-	  "subject": [
-	      "https://fhir.hub.example.com/Patient/uyhlm9ls2tmuwuk",
-	      "https://fhir.hub.example.com/Encounter/4aw1gs8f8r3yd2v"
-	  ]
-    }
+  "event": {
+    "hub.topic": "7jaa86kgdudewiaq0wtu",
+    "hub.event": "open-patient-chart",
+    "context": [
+      {
+        "key": "patient",
+        "resource": {
+          "resourceType": "Patient",
+          "id": "ewUbXT9RWEbSj5wPEdgRaBw3",
+          "identifier": [
+            {
+              "system": "urn:oid:1.2.840.114350",
+              "value": "185444"
+            },
+            {
+              "system": "urn:oid:1.2.840.114350.1.13.861.1.7.5.737384.27000",
+              "value": "2667"
+            }
+          ]
+        }
+      }
+    ]
+  }
 }
 ```
 
@@ -161,16 +182,221 @@ hub.callback=https%3A%2F%2Fapp.example.com%2Fsession%2Fcallback%2Fv7tfwuk17a&hub
 
 ```
 ## Event Catalog
-1. open-patient-chart
-1. switch-patient-chart
-1. close-patient-chart
-1. open-imaging-study
-1. switch-imaging-study
-1. close-imaging-study
-1. user-logout
-1. user-hibernates
+Each  event definition in the catalog, below, specifies a single event name, a description of the event, and the  required or optional contextual information associated with the event. Alongside the event name, the contextual information is used by the subscriber.
+
+FHIR is the interoperable data model used by FHIRcast. The fields within `context` are subsets of FHIR resources. Hubs MUST send the results of FHIR reads in the context, as specified below. For example, when the open-image-study event occurs, the notification sent to a subscriber MUST include the ImagingStudy FHIR resource. Hubs SHOULD send the results of an ImagingStudy FHIR read using the _\_elements\_ query parameter, like so:  `ImagingStudy/{id}?_elements=identifier,accession` and in accordance with the [FHIR specification](https://www.hl7.org/fhir/search.html#elements). 
+
+A FHIR server may not support the *\_elements* query parameter; a subscriber MUST gracefully handle receiving a full FHIR resource in the context of a notification.
+
+### open-patient-chart
+#### Description: 
+User opened patient's medical record. 
+#### Example: 
+```
+{
+  "context": [
+    {
+      "key": "patient",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "ewUbXT9RWEbSj5wPEdgRaBw3",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350",
+            "value": "185444"
+          },
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.861.1.7.5.737384.27000",
+            "value": "2667"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+Context | Optionality | FHIR operation to generate context|  Description
+--- | --- | --- | ---
+`patient` | Required| `Patient/{id}?\_elements=identifier` | FHIR Patient resource describing the patient whose chart is currently in context.
+`encounter` | Optional | `Encounter/{id}?\_elements=identifier` | FHIR Encounter resource in context in the newly opened patient's chart.
+
+
+### switch-patient-chart
+
+#### Description: 
+User changed from one open patient's medical record to another previously opened patient's medical record. The context documents the patient whose record is currently open.
+#### Example: 
+```
+{
+  "context": [
+    {
+      "key": "patient",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "ewUbXT9RWEbSj5wPEdgRaBw3",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350",
+            "value": "185444"
+          },
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.861.1.7.5.737384.27000",
+            "value": "2667"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+Context | Optionality | FHIR operation to generate context|  Description
+--- | --- | --- | ---
+`patient` | Required |  `Patient/{id}?\_elements=identifier` | FHIR Patient resource describing the patient whose chart is currently in context..
+`encounter` | Optional | `Encounter/{id}?\_elements=identifier` | FHIR Encounter resource in context in the newly opened patient's chart.
+
+
+### close-patient-chart
+
+#### Description: User closed patient's medical record. 
+
+#### Example: 
+```
+{ }
+```
+
+No context.
+
+### open-imaging-study
+#### Description: User opened record of imaging study.
+#### Example: 
+```
+{
+  "context": [
+    {
+      "key": "patient",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "ewUbXT9RWEbSj5wPEdgRaBw3",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350",
+            "value": "185444"
+          },
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.861.1.7.5.737384.27000",
+            "value": "2667"
+          }
+        ]
+      }
+    },
+    {
+      "key": "study",
+      "resource": {
+        "resourceType": "ImagingStudy",
+        "id": "8i7tbu6fby5ftfbku6fniuf",
+        "uid": "urn:oid:2.16.124.113543.6003.1154777499.30246.19789.3503430045",
+        "identifier": [
+          {
+            "system": "7678",
+            "value": "185444"
+          }
+        ],
+        "patient": {
+          "reference": "Patient/ewUbXT9RWEbSj5wPEdgRaBw3"
+        }
+      }
+    }
+  ]
+}
+```
+
+Context | Optionality | FHIR operation to generate context|  Description
+--- | --- | --- | ---
+`patient` | Optional| `Patient/{id}?_elements=identifier`| FHIR Patient resource describing the patient whose chart is currently in context.
+`study` | Required | `ImagingStudy/{id}?_elements=identifier,accession` | FHIR ImagingStudy resource in context. Note that in addition to the request identifier and accession elements, the DICOM uid and FHIR patient reference are included because they're required by the FHIR specification. 
+
+### switch-imaging-study
+#### Description: User changed from one open imaging study to another previously opened imaging study. The context documents the study, and optionally patient, for the currently open record.
+#### Example: 
+```
+{
+  "context": [
+    {
+      "key": "patient",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "ewUbXT9RWEbSj5wPEdgRaBw3",
+        "identifier": [
+          {
+            "system": "urn:oid:1.2.840.114350",
+            "value": "185444"
+          },
+          {
+            "system": "urn:oid:1.2.840.114350.1.13.861.1.7.5.737384.27000",
+            "value": "2667"
+          }
+        ]
+      }
+    },
+    {
+      "key": "study",
+      "resource": {
+        "resourceType": "ImagingStudy",
+        "id": "8i7tbu6fby5ftfbku6fniuf",
+        "uid": "urn:oid:2.16.124.113543.6003.1154777499.30246.19789.3503430045",
+        "identifier": [
+          {
+            "system": "7678",
+            "value": "185444"
+          }
+        ],
+        "patient": {
+          "reference": "Patient/ewUbXT9RWEbSj5wPEdgRaBw3"
+        }
+      }
+    }
+  ]
+}
+```
+
+Context | Optionality | FHIR operation to generate context|  Description
+--- | --- | --- | ---
+`patient` | Optional| `Patient/{id}?_elements=identifier` | FHIR Patient resource describing the patient whose chart is currently in context.
+`study` | Required | `ImagingStudy/{id}?_elements=identifier,accession` | FHIR ImagingStudy resource in context. Note that in addition to the request identifier and accession elements, the DICOM uid and FHIR patient reference are included because they're required by the FHIR specification. 
+
+### close-imaging-study
+
+#### Description: User closed imaging study.
+
+#### Example: 
+```
+{
+ }
+```
+
+No context.
+
+### user-logout
+#### Description: User gracefully exited the application.
+#### Example: 
+{
+}
+
+
+No Context 
+
+### user-hibernate
+#### Description: User temporarily suspended her session. The user's session will eventually resume.
+#### Example: 
+{
+}
+
+No Context 
 
 
 ## Get involved
 * [Log issues, contribute via github](https://github.com/fhircast)
 * [Converse at chat.fhir.org](https://chat.fhir.org/#narrow/stream/subscriptions)
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,30 +1,20 @@
 # FHIRcast - _modern, simple application context synchronization_
-
 ## Overview
+FHIRcast synchronizes healthcare applications in real time to show the same clinical content to a common user. For example, a radiologist often works in three disparate applications at the same time (a radiology information system, a PACS and a dictation system), she wants each of these three systems to display the same study or patient at the same time. FHIRcast isn't limited to radiology use-cases. Modeled after the common webhook design pattern and specifically the [W3C WebSub RFC](https://www.w3.org/TR/websub/), FHIRcast naturally extends the SMART on FHIR launch protocol to achieve tight integration between disparate, full-featured applications. FHIRcast builds on the [CCOW](https://en.wikipedia.org/wiki/CCOW) abstract model to specify an http-based and simple context synchronization specification that doesn't require a separate context manager. 
 
-FHIRcast synchronizes healthcare applications in real time to show the same clinical content to a common user. For example, a radiologist often works in three disparate applications at the same time (a radiology information system, a PACS and a dictation system), she wants each of these three systems to display the same study or patient at the same time. 
-
-FHIRcast isn't limited to radiology use-cases. Using [FHIR Subscriptions](https://www.hl7.org/fhir/subscription.html), FHIRcast naturally extends the SMART on FHIR launch protocol to achieve tight integration between disparate, full-featured applications. FHIRcast builds on the [CCOW](https://en.wikipedia.org/wiki/CCOW) abstract model to specify an http-based, simple and decentralized context synchronization specification. For simplicity, the below describes an app synchronizing with an EHR, but any user-facing application can synchronize with FHIRcast. While less common,  bidirectional communication between multiple applications is also possible.
-
+Adopting the WebSub terminology, the below describes an app as a subscriber synchronizing with an EHR in the role of a hub, but any user-facing application can synchronize with FHIRcast. While less common,  bidirectional communication between multiple applications is also possible.
 
 ### Why?
-
-The large number of vendor-specific or proprietary context synchronization methods in production use limit the industry's ability to enhance the very large number of integrations currently in production. In practice, these integrations are decentralized and simple. 
-
+The large number of vendor-specific or proprietary context synchronization methods in production limit the industry's ability to enhance the very large number of integrations currently in production. In practice, these integrations are decentralized and simple. 
 
 ## Synchronize
-
-An app creates a subscription to the EHR's UserSession and is then notified when the focus of the session changes, for example, by the clinician opening a patient's chart. The app deletes its subscription when it no longer wants to receive notifications.
-
-
-
+An app subscribes to specific workflow events for a given user's session, the subscription is verified and the app is then notified when those workflow events occur; for example, by the clinician opening a patient's chart. The app deletes its subscription when it no longer wants to receive notifications.
 [TODO: Simple, attractive image illustrating actors and key interactions]
 
 ### EHR launches SMART on FHIR App
+The EHR launches the app following the standard [SMART on FHIR EHR launch](http://www.hl7.org/fhir/smart-app-launch#ehr-launch-sequence) flow, including identifying the current EHR user using OpenID Connect. As part of the app launch, alongside the acess_token the EHR's authorization server identifies the base url to the hub, a unique, opaque identifier to the current user's session, 
 
-The EHR launches the app following the standard [SMART on FHIR EHR launch](http://www.hl7.org/fhir/smart-app-launch#ehr-launch-sequence) flow, including identifying the current EHR user using OpenID Connect. As part of the app launch, alongside the acess_token the EHR's authorization server identifies the current user's [UserSession](usersession/):
-
-#### SMART launch parameters include usersession
+#### SMART launch parameters include hub base url and session identifier
 ```
 {
   "access_token": "i8hweunweunweofiwweoijewiwe",
@@ -32,118 +22,155 @@ The EHR launches the app following the standard [SMART on FHIR EHR launch](http:
   "expires_in": 3600,
   "patient":  "123",
   "encounter": "456",
-  "usersession" : "789"
+  "imagingstudy": "789",
+  "cast-hub" : "https://hub.example.com",
+  "cast-session": "7jaa86kgdudewiaq0wtu",
 }
 ```
+Although FHIRcast works best with the SMART on FHIR launch and authorization process, it can also be used with implementation-specific launch and authz protocols. See [other launch scenarios]().
 
-Although FHIRcast works best with the SMART on FHIR launch and authorization process, it can also be used with implementation-specific launch and authz protocols.
+### App subscribes to session
+In this example, the app asks to be notified of the patient-chart-open and patient-chart-close events.  Note that the bearer access_token used to authenticate to the Hub was initially granted during the SMART launch.
 
-### App subscribes to UserSession changes
+Subscriber performs an HTTP POST to the hub base url with the following parameters.
 
-The app finds or creates an EventDefinition that describes the change it wants to be notified of. 
+Field | Optionality | Type | Description
+---------- | ----- | -------- | --------------
+hub.callback | Required | string | The Subscriber's callback URL where notifications should be delivered. The callback URL SHOULD be an unguessable URL that is unique per subscription.
+hub.mode | Required | string | The literal string "subscribe" or "unsubscribe", depending on the goal of the request.
+hub.topic | Required | string | The identifier of the user's session that the subscriber wishes to subscribe to or unsubscribe from. 
+hub.secret | Required | string | A subscriber-provided cryptographically random unique secret string that will be used to compute an HMAC digest delivered in each notification. This parameter MUST be less than 200 bytes in length.
+hub.events | Required | string | Comma-separated list of event types from the Event Catalog for which the Subscriber wants notifications.
+hub.lease_seconds | Optional | number | Number of seconds for which the subscriber would like to have the subscription active, given as a positive decimal integer. Hubs MAY choose to respect this value or not, depending on their own policies, and MAY set a default value if the subscriber omits the parameter. 
 
-```
-GET <fhir base url>/EventDefinition?name=patient-chart-open
-```
+Hubs MUST allow subscribers to re-request subscriptions that are already activated. Each subsequent request to a hub to subscribe or unsubscribe MUST override the previous subscription state for a specific topic, and callback URL combination once the action is verified. 
 
-```
-{
-  "resourceType": "EventDefinition",
-  "id": "abc",
-  "status": "active",
-  "name": "patient-chart-open",
-  "description": "Patient in focus changes in UserSession",
-  "trigger": {
-    "type": "named-event",
-    "data": {
-      "type": "UserSession"
-    },
-    "condition": {
-      "description": "Current UserSession.focus contains a Patient not in previous UserSession.focus",
-      "language": "text/fhirpath",
-      "expression": "this.focus.ofType(Patient) and this.focus != %previous.focus"
-    }
-  }
-}
-```
-
-[TODO - ask Bryn for correct syntax for multiple common workflow events]
-
-### The app creates a Subscription on the EHR's FHIR server for the given EventDefinition:
-
-In this example, the app asks to be notified of new events via a _rest-hook_ with the modified resource in the http body. FHIR Subscriptions also describes other possible channels. Note that the bearer access_token used to authenticate to the FHIR server was initially granted during the SMART launch.
+The callback URL MAY contain arbitrary query string parameters (e.g., ?foo=bar&red=fish). Hubs MUST preserve the query string during subscription verification by appending new parameters to the end of the list using the & (ampersand) character to join. When sending the content distribution request, the hub will make a POST request to the callback URL including any query string parameters in the URL portion of the request, not as POST body parameters.
 
 ```
-POST <fhir base url>/Subscription
+POST https://hub.example.com
+Host: hub.example.com
 Authorization: Bearer i8hweunweunweofiwweoijewiwe
+Content-Type: application/x-www-form-urlencoded
+
+hub.callback=https%3A%2F%2Fapp.example.com%2Fsession%2Fcallback%2Fv7tfwuk17a&hub.mode=subscribe&hub.topic=7jaa86kgdudewiaq0wtu&hub.secret=shhh-this-is-a-secret&hub.events=patient-open-chart,patient-close-chart
 ```
 
+#### Hub responds with successful creation
+If the hub URL supports FHIRcast and is able to handle the subscription or unsubscription request, it MUST respond to a subscription request with an HTTP 202 "Accepted" response to indicate that the request was received and will now be verified by the hub. The hub SHOULD perform the verification of intent as soon as possible.
+
+If a hub finds any errors in the subscription request, an appropriate HTTP error response code (4xx or 5xx) MUST be returned. In the event of an error, hubs SHOULD return a description of the error in the response body as plain text, used to assist the client developer in understanding the error. This is not meant to be shown to the end user. Hubs MAY decide to reject some callback URLs or topic URLs based on their own policies.
+
 ```
+HTTP/1.1 202 Accepted
+```
+
+### Hub may cancel subscription
+
+If (and when) the subscription is denied, the hub MUST inform the subscriber by sending an HTTP GET request to the subscriber's callback URL as given in the subscription request. This request has the following query string arguments appended.
+
+Field | Optionality | Type | Description
+--- | --- | --- | ---
+hub.mode | Required | string | The literal string "denied".
+hub.topic | Required | string | The topic given in the corresponding subscription request.
+hub.events| Required | string | A comma-separated list of events from the Event Catalog corresponding to the events string given in the corresponding subscription request. 
+hub.reason | Optional | string | The hub may include a reason for which the subscription has been denied. The subscription MAY be denied by the hub at any point (even if it was previously accepted). The Subscriber SHOULD then consider that the subscription is not possible anymore.
+
+```
+GET https://app.example.com/session/callback/v7tfwuk17a?hub.mode=denied&hub.topic=7jaa86kgdudewiaq0wtu&hub.events=patient-open-chart,patient-close-chart&hub.challenge=meu3we944ix80ox&hub.reason=session+unexpectedly+stopped HTTP 1.1
+Host: subscriber
+```
+
+
+#### Hub verifies callback url
+If (and when) the subscription is accepted, the hub MUST perform the verification of intent of the subscriber. The hub.callback url verification process ensures that the subscriber actually controls the callback url.
+
+In order to prevent an attacker from creating unwanted subscriptions on behalf of a subscriber (or unsubscribing desired ones), a hub must ensure that the subscriber did indeed send the subscription request. The hub verifies a subscription request by sending an HTTPS GET request to the subscriber's callback URL as given in the subscription request. This request has the following query string arguments appended:
+
+Field | Optionality | Type | Description
+---  | --- | --- | --- 
+hub.mode | Required | string | The literal string "subscribe" or "unsubscribe", which matches the original request to the hub from the subscriber.
+hub.topic | Required | string | The topic session id given in the corresponding subscription request.
+hub.events| Required | string | A comma-separated list of events from the Event Catalog corresponding to the events string given in the corresponding subscription request. 
+hub.challenge | Required | string | A hub-generated, random string that MUST be echoed by the subscriber to verify the subscription.
+hub.lease_seconds | Required | number | The hub-determined number of seconds that the subscription will stay active before expiring, measured from the time the verification request was made from the hub to the subscriber. Subscribers must renew their subscription before the lease seconds period is over to avoid interruption. 
+
+```
+GET https://app.example.com/session/callback/v7tfwuk17a?hub.mode=subscribe&hub.topic=7jaa86kgdudewiaq0wtu&hub.events=patient-open-chart,patient-close-chart&hub.challenge=meu3we944ix80ox HTTP 1.1
+Host: subscriber
+```
+
+The subscriber MUST confirm that the hub.topic corresponds to a pending subscription or unsubscription that it wishes to carry out. If so, the subscriber MUST respond with an HTTP success (2xx) code with a response body equal to the hub.challenge parameter. If the subscriber does not agree with the action, the subscriber MUST respond with a 404 "Not Found" response.
+
+```
+HTTP/1.1 200 Success
+Content-Type: text/html
+
+meu3we944ix80ox
+```
+
+The hub MUST consider other server response codes (3xx, 4xx, 5xx) to mean that the verification request has failed. If the subscriber returns an HTTP success (2xx) but the content body does not match the hub.challenge parameter, the hub MUST also consider verification to have failed.
+
+### Workflow event occurs and subscriber is notified
+
+In addition to a description of the subscribed event that just occurred, the notification to the subscriber also includes an ISO 8601 formatted timestamp in UTC and an event identifer that is universally unique for the hub. The timestamp should be used by subscribers to establish message affinity through the use of a message queue. The event identifier should be used to differentiate retried messages from user actions. 
+
+Using the hub.secret from the subscription request, the hub MUST generate an HMAC signature of the payload and include that signature in the request headers of the notification. The X-Hub-Signature header's value MUST be in the form method=signature where method is one of the recognized algorithm names and signature is the hexadecimal representation of the signature. The signature MUST be computed using the HMAC algorithm [RFC6151](https://www.w3.org/TR/websub/#bib-RFC6151)  with the request body as the data and the hub.secret as the key.
+
+Field | Optionality | Type | Description
+--- | --- | --- | ---
+Timestamp | Required | string | ISO 8601 timestamp in UTC describing the time at which the event occurred with subsecond accuracy. 
+Id | Required | string | Event identifier used to recognize retried notifications. This id MUST be globally unique for the hub, SHOULD be opaque to the subscriber and MAY be a GUID.
+Event | Required | object | A json object describing the event. See below.
+
+Field | Optionality | Type | Description
+--- | --- | --- | ---
+hub.topic | Required | string | The topic session id given in the subscription request. 
+hub.event| Required | string | The event that triggered this notification, taken from the list of events from the subscription request.
+subject | Required | array | A json array containing the new _focus_ of the user's session in the form of urls to FHIR resources. Common FHIR resources are: Patient, Encounter, ImagingStudy and List. The hub MUST only return FHIR resources that can be accessed with the existing OAuth2 access_token.
+```
+POST https://app.example.com/session/callback/v7tfwuk17a HTTP/1.1
+Host: subscriber
+X-Hub-Signature: sha256=dce85dc8dfde2426079063ad413268ac72dcf845f9f923193285e693be6ff3ae
+
 {
-  "resourceType": "Subscription",
-  "criteria": "UserSession?_id=123",
-  "topic": "<fhir base url>/EventDefinition/abc",
-  "channel": {
-    "type": "rest-hook",
-    "endpoint": "<app notification endpoint>/on-patientchartopen",
-    "payload": "application/fhir+json"
-  }
+  "timestamp": "2018-01-08T01:37:05.14",
+  "id": "q9v3jubddqt63n1",
+  "event":   {
+	  "hub.topic": "7jaa86kgdudewiaq0wtu",
+	  "hub.event": "open-patient-chart",
+	  "subject": [
+	      "https://fhir.hub.example.com/Patient/uyhlm9ls2tmuwuk",
+	      "https://fhir.hub.example.com/Encounter/4aw1gs8f8r3yd2v"
+	  ]
+    }
 }
 ```
-  
-### EHR responds with successful creation
-
-```
-201 Created
-Location: <fhir base url>/Subscription/sub00001
-```
-
-### EHR notifies app of change
-
-```
-PUT <app notification endpoint>/on-patientchartopen/UserSession
-```
-
-```
-{
-  "resourceType": "UserSession",
-  "id" : "xyz",
-  "user": "Practitioner/prov123",
-  "status" : {
-    "value" : "activating",
-    "source" : "user"
-  }
-  "workstation" : "Location/readingworkstation456",
-  "focus" : [
-    "Patient/789",
-    "Encounter/100009181"
-  ],
-  "created" : "2017-12-11T09:57:34.2112Z",
- }
-```
 
 
-### App unsubscribes to UserSession changes
+### App unsubscribes from session
+
+Note that this is the same as the subscription request with the single difference that the hub.mode MUST be equal to the string _unsubscribe_.
+```
+POST https://hub.example.com
+Host: hub
+Authorization: Bearer i8hweunweunweofiwweoijewiwe
+Content-Type: application/x-www-form-urlencoded
+
+hub.callback=https%3A%2F%2Fapp.example.com%2Fsession%2Fcallback%2Fv7tfwuk17a&hub.mode=unsubscribe&hub.topic=7jaa86kgdudewiaq0wtu&hub.secret=shhh-this-is-a-secret&hub.events=patient-open-chart,patient-close-chart
 
 ```
-DELETE <fhir base url>/Subscription/sub00001
-```
-
 ## Event Catalog
-
 1. open-patient-chart
 1. switch-patient-chart
 1. close-patient-chart
 1. open-imaging-study
 1. switch-imaging-study
 1. close-imaging-study
-1. user-login
 1. user-logout
 1. user-hibernates
 
-[TODO - define fhirpath / Event definitions with names for common workflow events]
 
 ## Get involved
-
 * [Log issues, contribute via github](https://github.com/fhircast)
 * [Converse at chat.fhir.org](https://chat.fhir.org/#narrow/stream/subscriptions)


### PR DESCRIPTION
Rewrite spec to move away from using the FHIR server as the session management server ("hub"). Use WebSub and more generally, a webhooks pattern, in it's place.